### PR TITLE
Make convert/2 a dirty CPU NIF

### DIFF
--- a/c_src/membrane_element_ffmpeg_swresample/converter.spec.exs
+++ b/c_src/membrane_element_ffmpeg_swresample/converter.spec.exs
@@ -30,3 +30,5 @@ spec create(
 # so you won't be able to resample only a couple of samples. The actual threshold depends on
 # conversion parameters.
 spec convert(payload, state) :: {:ok :: label, payload} | {:error :: label, reason :: atom}
+
+dirty :cpu, [convert: 2]


### PR DESCRIPTION
From time to time, the execution of convert takes longer than 1ms, so it has to be a dirty CPU NIF